### PR TITLE
Two small improvements for the defcustoms

### DIFF
--- a/helm-backup.el
+++ b/helm-backup.el
@@ -49,7 +49,7 @@
   :group 'helm-backup
   :type 'string)
 
-(defcustom helm-backup-git-binary "/usr/bin/git"
+(defcustom helm-backup-git-binary "git"
   "Git binary path."
   :group 'helm-backup
   :type 'string)

--- a/helm-backup.el
+++ b/helm-backup.el
@@ -47,6 +47,7 @@
 (defcustom helm-backup-path "~/.helm-backup"
   "Backup location."
   :group 'helm-backup
+  :set (lambda (symbol path) (set-default symbol (expand-file-name path)))
   :type 'string)
 
 (defcustom helm-backup-git-binary "git"


### PR DESCRIPTION
- Don't hardcode a path to git.  An absolute path is not necessary (the shell or Emacs can find the path themselves, and this makes absolutely no difference in speed).  ITOH, what we had hardcoded could be wrong on some systems and the user would have to make and keep an unnecessary configuration entry.

The user can still change the path to whatever he wants.

(I had the feeling I had already made a PR for that, but probably my memory was wrong.)

- Use a setter for helm-backup-path's defcustom to canonicalize filename

This will conanicalize the specified path (mainly, expand "~").  Dunno whether it makes a difference with the current version, probably not, but AFAICT some functions in Emacs only accept canonical filenames, so we are on the safe side for future changes and lose nothing.

TIA, Michael.