### PR TITLE
Do not provide a feature in features/support/env.el

### DIFF
--- a/features/support/env.el
+++ b/features/support/env.el
@@ -63,6 +63,4 @@
 (Teardown
  (setq helm-backup-path helm-backup-folder-repository-original-path))
 
-(provide 'env)
-
 ;;; env.el ends here


### PR DESCRIPTION
This is not a library intended to be loaded with `require`, so it
should not advertise itself as such by `provide`ing `env`.  Doing that
would cause conflicts with other packages that use `ecukes`.  This
file is automatically `load'ed by `ecukes-load-support`, defined in
"ecukes-load.el".  Other test related files of a project don't have to
load it explicitly.

Closes #22.