### PR TITLE
Use builtin path check/manipulation functions

### DIFF
--- a/helm-backup.el
+++ b/helm-backup.el
@@ -44,7 +44,7 @@
   "Backup system using git and helm."
   :group 'helm)
 
-(defcustom helm-backup-path "~/.helm-backup"
+(defcustom helm-backup-path "~/.helm-backup/"
   "Backup location."
   :group 'helm-backup
   :set (lambda (symbol path) (set-default symbol (expand-file-name path)))
@@ -78,7 +78,7 @@
 
 (defun helm-backup--exec-git-command (command &optional strip-last-newline)
   "Execute a git COMMAND inside backup repository, optionally STRIP-LAST-NEWLINE."
-  (when (file-directory-p (concat helm-backup-path "/.git"))
+  (when (file-directory-p (expand-file-name ".git" helm-backup-path))
     (let* ((default-directory helm-backup-path)
            (output (shell-command-to-string (combine-and-quote-strings (append '("git") command)))))
       (if strip-last-newline
@@ -88,14 +88,8 @@
 (defun helm-backup--transform-filename-for-git (filename)
   "Transform FILENAME to be used in git repository."
   (when (and filename
-             (helm-backup--is-absolute-filename filename))
+             (file-name-absolute-p filename))
     (substring filename 1)))
-
-(defun helm-backup--is-absolute-filename (filename)
-  "Check if a FILENAME is absolute or not."
-  (when (and filename
-             (string= (substring filename 0 1) "/"))
-    t))
 
 (defun helm-backup--copy-file-to-repository (filename)
   "Create folder in repository and copy file using FILENAME in it."
@@ -111,7 +105,7 @@
 (defun helm-backup--version-file (filename)
   "Version file using FILENAME in backup repository."
   (when (and filename
-             (helm-backup--is-absolute-filename filename)
+             (file-name-absolute-p filename)
              (file-exists-p filename)
              (not (helm-backup--file-excluded-p filename)))
     (helm-backup--init-git-repository)

--- a/test/helm-backup-test.el
+++ b/test/helm-backup-test.el
@@ -60,15 +60,6 @@
      ;; absolute filename
      (should (equal-including-properties (helm-backup--transform-filename-for-git "/absolute/path") "absolute/path")))))
 
-(ert-deftest helm-backup-is-absolute-filename-test ()
-  (test-wrapper
-   (lambda ()
-     ;; nil filename
-     (should (eql (helm-backup--is-absolute-filename nil) nil))
-     ;; relative filename
-     (should (eql (helm-backup--is-absolute-filename "relative/path") nil))
-     ;; absolute filename
-     (should (equal-including-properties (helm-backup--is-absolute-filename "/absolute/path") t)))))
 
 (ert-deftest helm-backup-exec-git-command-test ()
   (test-wrapper


### PR DESCRIPTION
Instead of `concat` path+filename use the cross-platform `expand-file-name`.
Use Emacs builtin `file-name-absolute-p` to check if a file
is absolute or not.

See https://github.com/emacscollective/no-littering/pull/64